### PR TITLE
Make italic text more visually pronounced

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -532,3 +532,11 @@
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
+
+/* Make italic markdown (*text*) more visually pronounced */
+.post-content em,
+.post-content i,
+.blog-post em,
+.blog-post i {
+  font-style: oblique 15deg;
+}


### PR DESCRIPTION
Make `em` and `i` elements in post content use `font-style: oblique 15deg` so that `*italic*` markdown looks more distinctly slanted.

Closes #63

Generated with [Claude Code](https://claude.ai/code)